### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product overview
+
+Single-package Next.js 16 portfolio site ([saisur.me](https://www.saisur.me)) using the Pages Router (`src/pages/`), React 18, and Tailwind CSS. No backend, database, Docker, or required environment variables.
+
+### Services
+
+| Service | Command | URL |
+|---------|---------|-----|
+| Next.js dev (primary) | `npm run dev` | http://localhost:3000 |
+| Next.js production | `npm run build` then `npm run start` | http://localhost:3000 |
+
+Only the Next.js dev server is required for local development and end-to-end testing.
+
+### Lint / test / build
+
+- **Install:** `npm install` (Node.js >= 20; `.nvmrc` specifies `20`)
+- **Lint:** `npm run lint` is broken on Next.js 16 — the CLI no longer includes a `lint` subcommand. Use `npx eslint . --ext .js,.jsx` instead. The repo has pre-existing quote-style violations in `src/components/Home.js`.
+- **Build:** `npm run build`
+- **Tests:** No automated test suite is configured in `package.json`.
+
+### Gotchas
+
+- **Next.js 16 CLI:** `next lint` was removed; `npm run lint` fails with "Invalid project directory provided, no such directory: .../lint". Use ESLint directly (see above).
+- **Portfolio route:** `/portfolio` works but is not linked from the home sidebar; navigate directly or via in-page links on the portfolio page.
+- **Standalone prototype:** `flower-test.html` at the repo root is not served by Next.js; open it separately if needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific instructions for developing this Next.js portfolio site.

## Contents

- Service startup commands (dev and production)
- Lint/build/test notes, including the Next.js 16 `next lint` removal workaround
- Known gotchas (portfolio route not in sidebar, standalone `flower-test.html`)

## Environment verification

- `npm install` — OK
- `npm run build` — OK (static pages: `/`, `/404`, `/portfolio`)
- `npm run dev` — OK at http://localhost:3000
- Browser walkthrough — home page (WebGL flower), portfolio page, navigation back

[portfolio-site-demo.mp4](https://cursor.com/agents/bc-4b8027e2-ee84-459c-93b2-b063432a2d30/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio-site-demo.mp4)

[Home page](https://cursor.com/agents/bc-4b8027e2-ee84-459c-93b2-b063432a2d30/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-page.webp)
[Portfolio page](https://cursor.com/agents/bc-4b8027e2-ee84-459c-93b2-b063432a2d30/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fportfolio-page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b8027e2-ee84-459c-93b2-b063432a2d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b8027e2-ee84-459c-93b2-b063432a2d30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

